### PR TITLE
Compose keys support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,14 @@ PREFIX=/usr/local
 BINDIR=$(PREFIX)/bin
 
 CFLAGS=-Wall -Wextra -Wno-unused-parameter -Wno-parentheses
-LDFLAGS=-lrt -lm -lutil -lwayland-client -lxkbcommon -Ltsm -lhtsm
 
 VPATH=$(PROTDIR)/stable/xdg-shell
+LIBS=-lrt -lm -lutil -lwayland-client -lxkbcommon -Ltsm -lhtsm
 OBJ=xdg-shell.o gtk-primary-selection.o glyph.o main.o
 GEN=xdg-shell.c xdg-shell.h gtk-primary-selection.c gtk-primary-selection.h
 
 havoc: tsm $(OBJ)
-	$(CC) $(CFLAGS) -o $@ $(OBJ) $(LDFLAGS)
+	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LIBS)
 
 install: havoc
 	install -D -t $(DESTDIR)$(BINDIR) havoc

--- a/glyph.c
+++ b/glyph.c
@@ -965,6 +965,11 @@ static void rasterize_sorted_edges(struct bitmap *result, struct edge *e,
 								   off_x,
 								   scan_y_top);
 				if (z != NULL) {
+					if (j == 0 && off_y != 0) {
+						if (z->ey < scan_y_top) {
+							z->ey = scan_y_top;
+						}
+					}
 					assert(z->ey >= scan_y_top);
 					/* insert at front */
 					z->next = active;
@@ -1534,9 +1539,9 @@ int font_init(int size, char *path, int *w, int *h)
 	font.height = font.ascent - descent + linegap;
 	font.width = get_width(&font);
 
-	font.ascent *= font.scale;
-	font.width *= font.scale;
-	font.height *= font.scale;
+	font.ascent = floor(font.scale * font.ascent);
+	font.width = ceil(font.scale * font.width);
+	font.height = ceil(font.scale * font.height);
 
 	*w = font.width;
 	*h = font.height;

--- a/havoc.cfg
+++ b/havoc.cfg
@@ -1,13 +1,21 @@
-[general]
-# absolute path to program, eg: /bin/bash, /bin/tmux, /bin/mc, /bin/nvim...
-shell=/bin/sh
+[child]
+# program to run in child process
+program=bash
 
+[window]
 # opacity of background from 0 (fully transparent) to 255 (fully opaque)
 opacity=230
 
-# size of terminal window
+# render a margin to exactly match window size hints from the compositor
+margin=no
+
+[terminal]
+# size of terminal
 rows=16
 columns=140
+
+# number of lines to keep in scrollback
+scrollback=1000
 
 [font]
 # heigth of a single glyph in pixels

--- a/main.c
+++ b/main.c
@@ -766,7 +766,7 @@ static void kbd_mods(void *data, struct wl_keyboard *k, uint32_t serial,
 		return;
 
 	xkb_state_update_mask(term.xkb_state, depressed, latched, locked,
-			      group, 0, 0);
+			      0, 0, group);
 
 	m = xkb_state_serialize_mods(term.xkb_state, XKB_STATE_MODS_EFFECTIVE);
 

--- a/main.c
+++ b/main.c
@@ -85,6 +85,7 @@ static struct {
 
 	struct {
 		int fd;
+		uint32_t key;
 		xkb_keysym_t sym;
 		uint32_t unicode;
 		struct itimerspec its;
@@ -700,7 +701,6 @@ static xkb_keysym_t process_key(xkb_keysym_t sym)
 	case XKB_COMPOSE_CANCELLED:
 		return XKB_KEY_NoSymbol;
 	case XKB_COMPOSE_NOTHING:
-		return sym;
 	default:
 		return sym;
 	}
@@ -715,10 +715,11 @@ static void kbd_key(void *data, struct wl_keyboard *k, uint32_t serial,
 	uint32_t unicode;
 
 	if (state == WL_KEYBOARD_KEY_STATE_RELEASED) {
-		reset_repeat();
+		if (term.repeat.key == key)
+			reset_repeat();
 		return;
 	}
-	
+
 	num_syms = xkb_state_key_get_syms(term.xkb_state, key + 8, &syms); 
 
 	sym = XKB_KEY_NoSymbol;
@@ -747,6 +748,7 @@ static void kbd_key(void *data, struct wl_keyboard *k, uint32_t serial,
 		unicode = xkb_keysym_to_utf32(sym);
 
 		if (xkb_compose_state_get_status(term.xkb_compose_state) != XKB_COMPOSE_COMPOSING) {
+			term.repeat.key = key;
 			term.repeat.sym = sym;
 			term.repeat.unicode = unicode;
 			timerfd_settime(term.repeat.fd, 0, &term.repeat.its, NULL);

--- a/main.c
+++ b/main.c
@@ -652,14 +652,14 @@ static void kbd_keymap(void *data, struct wl_keyboard *k, uint32_t fmt,
 			term.xkb_compose_state = compose_state;
 			term.xkb_compose_table = compose_table;
 		} else {
-			fprintf(stderr, "could not create XKB compose state.  "
-				"Disabiling compose.\n");
+			fprintf(stderr, "could not create XKB compose state. "
+				"Disabling compose.\n");
 			xkb_compose_table_unref(compose_table);
 			compose_table = NULL;
 		}
 	} else {
-		fprintf(stderr, "could not create XKB compose table for locale '%s'.  "
-			"Disabiling compose\n", getenv("LANG"));
+		fprintf(stderr, "could not create XKB compose table for locale '%s'.\n",
+			getenv("LANG"));
 	}
 
 	xkb_keymap_unref(term.xkb_keymap);

--- a/main.c
+++ b/main.c
@@ -1372,8 +1372,10 @@ retry:
 	setup_pty(argv);
 
 	if (font_init(term.cfg.font_size, term.cfg.font_path,
-		      &term.cwidth, &term.cheight) < 0)
+		      &term.cwidth, &term.cheight) < 0) {
+		fprintf(stderr, "could not load font\n");
 		goto efont;
+	}
 
 	term.xkb_ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
 	if (term.xkb_ctx == NULL)

--- a/tsm/tsm-vte.c
+++ b/tsm/tsm-vte.c
@@ -2305,7 +2305,7 @@ bool tsm_vte_handle_keyboard(struct tsm_vte *vte, uint32_t keysym,
 
 	switch (keysym) {
 		case XKB_KEY_BackSpace:
-			vte_write(vte, "\x08", 1);
+			vte_write(vte, "\x7f", 1);
 			return true;
 		case XKB_KEY_Tab:
 		case XKB_KEY_KP_Tab:


### PR DESCRIPTION
Now it is possible to type ~, ã etc.
It is an adaptation of the weston-terminal way. The ifdefs were removed and the function kbd_key was modified, because there should not be repetition during composing. For the first, weston uses the ifdefs to disable composing on older versions of xkbcommon (< 5.0). 