### PR TITLE
suppress events for more modifier keys

### DIFF
--- a/main.c
+++ b/main.c
@@ -733,6 +733,11 @@ static void kbd_key(void *data, struct wl_keyboard *k, uint32_t serial,
 	case XKB_KEY_Super_R:
 	case XKB_KEY_Hyper_L:
 	case XKB_KEY_Hyper_R:
+	case XKB_KEY_ISO_Level3_Shift:
+	case XKB_KEY_ISO_Level3_Lock:
+	case XKB_KEY_ISO_Level5_Shift:
+	case XKB_KEY_ISO_Level5_Lock:
+	case XKB_KEY_Caps_Lock:
 		return;
 	}
 


### PR DESCRIPTION
kbd_key() already suppresses events for various modifier keys; but with the
neo2 layout, some of them still go through, causing e.g. the cursor in nano
to jump a line down or causing vi to leave insert mode when I press the
level3 shift key in order to enter characters like brackets.

Add the missing modifier keys that I've noticed.