### PR TITLE
Implement xdg-decoration-unstable-v1 to request server side decorations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.a
 xdg-shell.[ch]
 gtk-primary-selection.[ch]
+xdg-decoration-unstable-v1.[ch]
 havoc

--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,11 @@ VERSION="0.4.0-git"
 CFLAGS ?= -Wall -Wextra -Wno-unused-parameter -Wno-parentheses
 override CFLAGS += -DVERSION=\"$(VERSION)\"
 
-VPATH=$(WAYLAND_PROTOCOLS_DIR)/stable/xdg-shell
+VPATH=$(WAYLAND_PROTOCOLS_DIR)/stable/xdg-shell:$(WAYLAND_PROTOCOLS_DIR)/unstable/xdg-decoration
 LIBS=-lrt -lm -lutil -lwayland-client -lwayland-cursor -lxkbcommon -Ltsm -lhtsm
-OBJ=xdg-shell.o gtk-primary-selection.o glyph.o main.o
-GEN=xdg-shell.c xdg-shell.h gtk-primary-selection.c gtk-primary-selection.h
+OBJ=xdg-shell.o xdg-decoration-unstable-v1.o gtk-primary-selection.o glyph.o main.o
+GEN=xdg-shell.c xdg-shell.h xdg-decoration-unstable-v1.c \
+	xdg-decoration-unstable-v1.h gtk-primary-selection.c gtk-primary-selection.h
 
 havoc: tsm $(OBJ)
 	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LIBS)

--- a/havoc.cfg
+++ b/havoc.cfg
@@ -9,6 +9,9 @@ opacity=230
 # render a margin to exactly match window size hints from the compositor
 margin=no
 
+# request server side decorations if available by the compositor [yes|no|auto]
+decorations=auto
+
 [terminal]
 # size of terminal
 rows=16


### PR DESCRIPTION
This allows requesting server side decorations if supported by the compositor.
Adds a new config option `window.decorations` with values
- `yes`  (always request server side decorations)
- `no`   (always request client side decorations, e.g. no decorations)
- `auto` (tell the compositor to use whatever it prefers)

The new setting defaults to `auto`.

---
I am not sure about the default for the new setting, feel free to request changes.