### PR TITLE
Scroll buffer to bottom on terminal input

### DIFF
--- a/havoc.cfg
+++ b/havoc.cfg
@@ -20,6 +20,9 @@ columns=140
 # number of lines to keep in scrollback
 scrollback=1000
 
+# when the scrolled up any keyboard input will jump the buffer to the bottom
+scroll to bottom on input=no
+
 [font]
 # height of a single glyph in pixels
 size=18

--- a/main.c
+++ b/main.c
@@ -166,6 +166,7 @@ static struct {
 		char shell[32];
 		int col, row;
 		int scrollback;
+		bool scroll_to_bottom_on_input;
 		bool margin;
 		unsigned char opacity;
 		enum deco decorations;
@@ -178,6 +179,7 @@ static struct {
 	.cfg.col = 80,
 	.cfg.row = 24,
 	.cfg.scrollback = 0,
+	.cfg.scroll_to_bottom_on_input = false,
 	.cfg.margin = false,
 	.cfg.opacity = 0xff,
 	.cfg.decorations = DECO_AUTO,
@@ -1035,9 +1037,12 @@ static void kbd_key(void *data, struct wl_keyboard *k, uint32_t serial,
 		b = b->next;
 	}
 
-	if (!action)
-		tsm_vte_handle_keyboard(term.vte, sym, XKB_KEY_NoSymbol,
-					term.mods, unicode);
+	if (!action) {
+		bool vte_write_success = tsm_vte_handle_keyboard(term.vte, sym, XKB_KEY_NoSymbol,
+								 term.mods, unicode);
+		if (vte_write_success && term.cfg.scroll_to_bottom_on_input && tsm_screen_sb_reset(term.screen))
+			term.need_redraw = true;
+	}
 
 	if (xkb_keymap_key_repeats(term.xkb_keymap, key + 8)) {
 		term.repeat.key = key;
@@ -1687,6 +1692,8 @@ static void terminal_config(char *key, char *val)
 		term.cfg.col = cfg_num(val, 10, 1, 1000);
 	else if (strcmp(key, "scrollback") == 0)
 		term.cfg.scrollback = cfg_num(val, 10, 0, INT_MAX);
+	else if (strcmp(key, "scroll to bottom on input") == 0)
+		term.cfg.scroll_to_bottom_on_input = strcmp(val, "yes") == 0;
 }
 
 static void font_config(char *key, char *val)

--- a/tsm/libtsm.h
+++ b/tsm/libtsm.h
@@ -156,7 +156,7 @@ void tsm_screen_sb_up(struct tsm_screen *con, int num);
 void tsm_screen_sb_down(struct tsm_screen *con, int num);
 void tsm_screen_sb_page_up(struct tsm_screen *con, int num);
 void tsm_screen_sb_page_down(struct tsm_screen *con, int num);
-void tsm_screen_sb_reset(struct tsm_screen *con);
+bool tsm_screen_sb_reset(struct tsm_screen *con);
 
 void tsm_screen_set_def_attr(struct tsm_screen *con,
 			     const struct tsm_screen_attr *attr);

--- a/tsm/tsm-screen.c
+++ b/tsm/tsm-screen.c
@@ -886,16 +886,17 @@ void tsm_screen_sb_page_down(struct tsm_screen *con, int num)
 }
 
 SHL_EXPORT
-void tsm_screen_sb_reset(struct tsm_screen *con)
+bool tsm_screen_sb_reset(struct tsm_screen *con)
 {
 	if (!con->sb_pos)
-		return;
+		return false;
 
 	screen_inc_age(con);
 	/* TODO: more sophisticated ageing */
 	con->age = con->age_cnt;
 
 	con->sb_pos = NULL;
+	return true;
 }
 
 SHL_EXPORT


### PR DESCRIPTION
Normal behavior on most terminal emulators is that the scrollback buffer jumps to bottom (if scrolled up) when something is typed into the terminal. This should emulate that behavior.