### PR TITLE
add meson as a build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 xdg-shell.*
 xdg-decoration-unstable-v1.*
 primary-selection-unstable-v1.*
+*-client-protocol.[ch]
 havoc

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ WAYLAND_SCANNER ?= wayland-scanner
 CFLAGS ?= -g -O2
 CDEFS = -DVERSION='$(VERSION)' -D_XOPEN_SOURCE=700
 
-WAYLAND_PROTOCOLS_DIR != $(PKG_CONFIG) --variable=pkgdatadir wayland-protocols
+WAYLAND_PROTOCOLS_DIR := $(shell $(PKG_CONFIG) --variable=pkgdatadir wayland-protocols)
 
 LIBRARIES = wayland-client wayland-cursor xkbcommon
-PKG_CFLAGS != $(PKG_CONFIG) --cflags $(LIBRARIES)
-PKG_LIBS != $(PKG_CONFIG) --libs $(LIBRARIES)
+PKG_CFLAGS := $(shell $(PKG_CONFIG) --cflags $(LIBRARIES))
+PKG_LIBS := $(shell $(PKG_CONFIG) --libs $(LIBRARIES))
 
 LIBS = -lm -lutil $(PKG_LIBS)
 

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,11 @@ XML = \
 	primary-selection-unstable-v1.xml
 
 GEN = \
-	xdg-shell.h \
+	xdg-shell-client-protocol.h \
 	xdg-shell.c \
-	xdg-decoration-unstable-v1.h \
+	xdg-decoration-unstable-v1-client-protocol.h \
 	xdg-decoration-unstable-v1.c \
-	primary-selection-unstable-v1.h \
+	primary-selection-unstable-v1-client-protocol.h \
 	primary-selection-unstable-v1.c
 
 OBJ = \
@@ -59,7 +59,7 @@ $(OBJ): $(GEN)
 .xml.c:
 	$(WAYLAND_SCANNER) private-code < $< > $@
 
-.xml.h:
+%-client-protocol.h: %.xml
 	$(WAYLAND_SCANNER) client-header < $< > $@
 
 xdg-shell.xml:

--- a/main.c
+++ b/main.c
@@ -21,9 +21,9 @@
 #include <wayland-cursor.h>
 
 #include "tsm/libtsm.h"
-#include "xdg-shell.h"
-#include "primary-selection-unstable-v1.h"
-#include "xdg-decoration-unstable-v1.h"
+#include "xdg-shell-client-protocol.h"
+#include "primary-selection-unstable-v1-client-protocol.h"
+#include "xdg-decoration-unstable-v1-client-protocol.h"
 
 #define ARRAY_LENGTH(a) (sizeof (a) / sizeof (a)[0])
 

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,55 @@
+project(
+	'havoc',
+	'c',
+	version : '0.6.0',
+	meson_version : '>= 1.8.0',
+	license : 'CC0-1.0 OR MIT',
+	license_files : 'LICENSE',
+)
+
+compiler_flags = [
+	'-Wno-unused-parameter',
+	'-Wno-parentheses',
+	'-Wno-format-overflow',
+]
+
+cc = meson.get_compiler('c')
+add_project_arguments(
+	cc.get_supported_arguments(compiler_flags),
+	language: 'c'
+)
+
+add_project_arguments('-DVERSION="@0@"'.format(meson.project_version()), language : 'c')
+
+xkbcommon = dependency('xkbcommon')
+wayland_client = dependency('wayland-client')
+wayland_cursor = dependency('wayland-cursor')
+m_dep = cc.find_library('m', required : false)
+
+subdir('tsm')
+
+wl = import('wayland')
+
+executable(
+	'havoc',
+	sources: [
+		'glyph.c',
+		'main.c',
+		wl.scan_xml(wl.find_protocol('xdg-shell')),
+		wl.scan_xml(wl.find_protocol('xdg-decoration', state: 'unstable', version: 1)),
+		wl.scan_xml(wl.find_protocol('primary-selection', state: 'unstable', version: 1)),
+	],
+	dependencies: [
+		wayland_client,
+		wayland_cursor,
+		xkbcommon,
+		m_dep,
+	],
+	link_with: [
+		htsm
+	],
+	install : true,
+)
+
+install_data('havoc.cfg', rename: 'example.cfg')
+install_data(meson.project_license_files(), install_dir: get_option('datadir') / 'licenses' / meson.project_name())

--- a/tsm/meson.build
+++ b/tsm/meson.build
@@ -1,0 +1,16 @@
+htsm = static_library(
+	'htsm',
+	sources: [
+		'wcwidth.c',
+		'shl-htable.c',
+		'tsm-render.c',
+		'tsm-screen.c',
+		'tsm-selection.c',
+		'tsm-unicode.c',
+		'tsm-vte-charsets.c',
+		'tsm-vte.c',
+	],
+	dependencies: [
+		xkbcommon
+	],
+)


### PR DESCRIPTION
Also added some portability changes for MacOS/BSD.

I found that almost all Wayland-related projects use meson as the build system, including libwayland. So I learned how to use meson and write meson.build, which is very easy and the scripts are very clear and easy to understand. I highly recommend it to you.

The modified code has been tested on Linux and MacOS with #58. I believe it will work on FreeBSD as well. If you can help test it on FreeBSD, it will be much appreciated.
