### PR TITLE
added instaling config to the make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,13 @@ VERSION = "0.7.0-git"
 
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
+ifeq ($(shell whoami), root)
+CFGDIR = /etc
+else ifneq (, ${XDG_CONFIG_HOME})
+CFGDIR = ${XDG_CONFIG_HOME}/havoc
+else ifneq (, ${HOME})
+CFGDIR = ${HOME}/.config/havoc
+endif
 
 PKG_CONFIG ?= pkg-config
 WAYLAND_SCANNER ?= wayland-scanner
@@ -87,10 +94,12 @@ fractional-scale-v1.xml:
 
 install: havoc
 	mkdir -p $(DESTDIR)$(BINDIR)
-	install -m 755 havoc $(DESTDIR)$(BINDIR)/havoc
+	install -m 755 havoc.cfg $(CFGDIR)/havoc.cfg  
+	install -m 755 havoc $(DESTDIR)$(BINDIR)
 
 uninstall:
 	rm $(DESTDIR)$(BINDIR)/havoc
+	rm $(CFGDIR)/havoc.cfg
 
 clean:
 	rm -f havoc $(XML) $(GEN) $(OBJ)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ make install
 ## Configure
 
 havoc will search for a file called `havoc.cfg` in `$XDG_CONFIG_HOME/havoc/` first,
-then in `$HOME/.config/havoc/` and last in the current working directory.
+then in `$HOME/.config/havoc/` then in `/etc/havoc.cfg` and last in the current working directory.
 
 See the example `havoc.cfg` for available options.
 

--- a/main.c
+++ b/main.c
@@ -1979,6 +1979,11 @@ static FILE *open_config(void)
 			return f;
 	}
 
+	snprintf(path, sizeof(path), "/etc/%s", CONF_FILE);
+	f = fopen(path, "r");
+	if (f)
+		return f;
+	
 	f = fopen(CONF_FILE, "r");
 	return f;
 }


### PR DESCRIPTION
fixed the lack of the default config file when running make install also added /etc/havoc.cfg as global config path